### PR TITLE
refactor: move examples to com.example package layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-Abc
+# Java Examples
+
+A collection of small Java programs demonstrating core concepts.
+
+## Contents
+
+Source is organized under `src/main/java/com/example`:
+
+- **array** – demonstrates arrays with a simple `Student` class.
+- **calculator** – basic arithmetic operations using a helper class.
+- **encapsulation** – illustrates encapsulation through getters and setters.
+- **staticdemo** – shows static variables, methods, and blocks.
+- **strings** – experiments with common `String` operations.
+
+## Running the examples
+
+From the repository root:
+
+```bash
+# Compile all examples
+mkdir -p out
+find src/main/java -name "*.java" -print0 | xargs -0 javac -d out
+
+# Run an example (replace com.example.array.Demo with the class you want to run)
+java -cp out com.example.array.Demo
+```
+
+Each package contains one or more classes with a `main` method that can be executed in this way.

--- a/src/main/java/com/example/array/Demo.java
+++ b/src/main/java/com/example/array/Demo.java
@@ -1,4 +1,4 @@
-package Array;
+package com.example.array;
 
 public class Demo {
     public static void main(String[] args) {

--- a/src/main/java/com/example/array/Student.java
+++ b/src/main/java/com/example/array/Student.java
@@ -1,4 +1,4 @@
-package Array;
+package com.example.array;
 
 public class Student {
 

--- a/src/main/java/com/example/calculator/Calculator.java
+++ b/src/main/java/com/example/calculator/Calculator.java
@@ -1,4 +1,4 @@
-package Calculator;
+package com.example.calculator;
 
 import java.util.Scanner;
 

--- a/src/main/java/com/example/calculator/HelperClass.java
+++ b/src/main/java/com/example/calculator/HelperClass.java
@@ -1,4 +1,4 @@
-package Calculator;
+package com.example.calculator;
 
 public class HelperClass {
     int J = 10;

--- a/src/main/java/com/example/encapsulation/EncapsulationDemo.java
+++ b/src/main/java/com/example/encapsulation/EncapsulationDemo.java
@@ -1,4 +1,4 @@
-package Encapsulation;
+package com.example.encapsulation;
 
 public class EncapsulationDemo {
     public static void main(String[] args) {

--- a/src/main/java/com/example/encapsulation/Humans.java
+++ b/src/main/java/com/example/encapsulation/Humans.java
@@ -1,4 +1,4 @@
-package Encapsulation;
+package com.example.encapsulation;
 
 public class Humans {
 

--- a/src/main/java/com/example/staticdemo/StaticBlock.java
+++ b/src/main/java/com/example/staticdemo/StaticBlock.java
@@ -1,4 +1,4 @@
-package StaticDemo;
+package com.example.staticdemo;
 
 class Cars {
     String brand;

--- a/src/main/java/com/example/staticdemo/StaticMethods.java
+++ b/src/main/java/com/example/staticdemo/StaticMethods.java
@@ -1,4 +1,4 @@
-package StaticDemo;
+package com.example.staticdemo;
 
 class Phones {
     // instance variables

--- a/src/main/java/com/example/staticdemo/StaticVariables.java
+++ b/src/main/java/com/example/staticdemo/StaticVariables.java
@@ -1,4 +1,4 @@
-package StaticDemo;
+package com.example.staticdemo;
 
 class Phone {
     String Name;

--- a/src/main/java/com/example/strings/StringsTest.java
+++ b/src/main/java/com/example/strings/StringsTest.java
@@ -1,4 +1,4 @@
-package Strings;
+package com.example.strings;
 
 public class StringsTest {
     public static void main(String[] args) {


### PR DESCRIPTION
## Summary
- relocate sources under standard `src/main/java/com/example` structure
- update package declarations and README instructions for new layout

## Testing
- `mkdir -p out && find src/main/java -name "*.java" -print0 | xargs -0 javac -d out`
- `java -cp out com.example.array.Demo | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688e7474baa88322bc5152985a08d0d7